### PR TITLE
feat(backend): prevent logging errors when binding keys don't match

### DIFF
--- a/server/safers/rmq/rmq.py
+++ b/server/safers/rmq/rmq.py
@@ -211,6 +211,6 @@ class RMQ(object):
                         logger.error(e)
 
         if unhandled_method:
-            logger.error(
+            logger.info(
                 f"'{method.routing_key}' does not match any BINDING_KEYS"
             )


### PR DESCRIPTION
Prevent logging errors when binding keys don't match, as this generates a needless entry in sentry.