### PR TITLE
feat(backend): remove distinction between local & remote users

### DIFF
--- a/server/safers/alerts/views.py
+++ b/server/safers/alerts/views.py
@@ -20,8 +20,6 @@ from drf_spectacular.utils import extend_schema, extend_schema_field, OpenApiExa
 from safers.core.decorators import swagger_fake
 from safers.core.filters import CaseInsensitiveChoiceFilter, DefaultFilterSetMixin, MultiFieldOrderingFilter
 
-from safers.users.permissions import IsRemote
-
 from safers.alerts.models import Alert, AlertType, AlertSource
 from safers.alerts.serializers import AlertViewSetSerializer
 
@@ -123,7 +121,7 @@ class AlertViewSet(
 
     lookup_field = "id"
     lookup_url_kwarg = "alert_id"
-    permission_classes = [IsAuthenticated, IsRemote]
+    permission_classes = [IsAuthenticated]
     serializer_class = AlertViewSetSerializer
 
     def get_serializer_context(self):

--- a/server/safers/data/views/views_metadata.py
+++ b/server/safers/data/views/views_metadata.py
@@ -12,14 +12,12 @@ from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiRespon
 
 from safers.core.authentication import TokenAuthentication
 
-from safers.users.permissions import IsRemote
-
 METADATA_FORMAT_TYPES = ["json", "text"]
 
 
 class DataLayerMetadataView(views.APIView):
 
-    permission_classes = [IsAuthenticated, IsRemote]
+    permission_classes = [IsAuthenticated]
 
     @extend_schema(
         parameters=[

--- a/server/safers/events/views.py
+++ b/server/safers/events/views.py
@@ -21,8 +21,6 @@ from drf_spectacular.utils import extend_schema, extend_schema_field, OpenApiTyp
 from safers.core.decorators import swagger_fake
 from safers.core.filters import DefaultFilterSetMixin, MultiFieldOrderingFilter
 
-from safers.users.permissions import IsRemote
-
 from safers.events.models import Event, EventStatusChoices
 from safers.events.serializers import EventSerializer
 
@@ -134,7 +132,7 @@ class EventViewSet(
 
     lookup_field = "id"
     lookup_url_kwarg = "event_id"
-    permission_classes = [IsAuthenticated, IsRemote]
+    permission_classes = [IsAuthenticated]
     serializer_class = EventSerializer
 
     @swagger_fake(Event.objects.none())

--- a/server/safers/notifications/views.py
+++ b/server/safers/notifications/views.py
@@ -19,8 +19,6 @@ from drf_spectacular.utils import extend_schema, extend_schema_field, OpenApiRes
 from safers.core.decorators import swagger_fake
 from safers.core.filters import DefaultFilterSetMixin, CaseInsensitiveChoiceFilter
 
-from safers.users.permissions import IsRemote
-
 from safers.notifications.models import Notification, NotificationSourceChoices, NotificationTypeChoices, NotificationScopeChoices, NotificationRestrictionChoices
 from safers.notifications.serializers import NotificationSerializer
 
@@ -137,7 +135,7 @@ class NotificationViewSet(viewsets.ReadOnlyModelViewSet):
 
     lookup_field = "id"
     lookup_url_kwarg = "notification_id"
-    permission_classes = [IsAuthenticated, IsRemote]
+    permission_classes = [IsAuthenticated]
     serializer_class = NotificationSerializer
 
     @swagger_fake(Notification.objects.none())

--- a/server/safers/social/views/views_tweets.py
+++ b/server/safers/social/views/views_tweets.py
@@ -14,8 +14,6 @@ from drf_spectacular.utils import extend_schema
 
 from safers.core.authentication import TokenAuthentication
 
-from safers.users.permissions import IsRemote
-
 from safers.social.models import Tweet
 from safers.social.serializers import TweetSerializer, TweetViewSerializer
 
@@ -25,7 +23,7 @@ class TweetView(views.APIView):
     Takes events from social media module and returns individual tweets
     """
 
-    permission_classes = [IsAuthenticated, IsRemote]
+    permission_classes = [IsAuthenticated]
 
     def get_serializer_context(self):
         return {

--- a/server/safers/users/admin/admin_users.py
+++ b/server/safers/users/admin/admin_users.py
@@ -7,28 +7,6 @@ from django.utils.translation import gettext_lazy as _
 from safers.core.widgets import DataListWidget, JSONWidget
 from safers.users.models import User, ProfileDirection, Organization, Role
 
-###########
-# filters #
-###########
-
-
-class LocalOrRemoteFilter(admin.SimpleListFilter):
-    title = "authentication type"
-    parameter_name = "_ignore"  # ignoring parameter_name and computing qs manually
-
-    def lookups(self, request, model_admin):
-        return (
-            ("_is_local", _("Local")),
-            ("_is_remote", _("Remote")),
-        )
-
-    def queryset(self, request, qs):
-        value = self.value()
-        if value:
-            qs = qs.filter(**{value: True})
-        return qs
-
-
 #########
 # forms #
 #########
@@ -164,12 +142,10 @@ class UserAdmin(DjangoUserAdmin):
         "is_active",
         "accepted_terms",
         "status",
-        "get_authentication_type_for_list_display",
         "organization_name",
         "role_name",
     )
     list_filter = (
-        LocalOrRemoteFilter,
         "status",
         "organization_name",
         "role_name",
@@ -178,15 +154,6 @@ class UserAdmin(DjangoUserAdmin):
         "id",
         "auth_id",
     ) + DjangoUserAdmin.readonly_fields
-
-    @admin.display(description="AUTHENTICATION TYPE")
-    def get_authentication_type_for_list_display(self, instance):
-        authentication_type = "unknown"
-        if instance.is_local:
-            authentication_type = "local"
-        elif instance.is_remote:
-            authentication_type = "remote"
-        return authentication_type
 
     @admin.display(
         description="Toggles the term acceptance of the selected users"

--- a/server/safers/users/models/models_users.py
+++ b/server/safers/users/models/models_users.py
@@ -83,21 +83,6 @@ class UserManager(BaseUserManager):
 
         return self.create_user(username, email, password, **extra_fields)
 
-    def get_queryset(self):
-        """
-        Add some calculated fields to the default queryset
-        """
-        qs = super().get_queryset()
-
-        return qs.annotate(
-            _is_local=ExpressionWrapper(
-                Q(auth_id__isnull=True), output_field=models.BooleanField()
-            ),
-            _is_remote=ExpressionWrapper(
-                Q(auth_id__isnull=False), output_field=models.BooleanField()
-            )
-        )
-
 
 class UserQuerySet(models.QuerySet):
     def active(self):
@@ -105,12 +90,6 @@ class UserQuerySet(models.QuerySet):
 
     def inactive(self):
         return self.filter(is_active=False)
-
-    def local(self):
-        return self.filter(_is_local=True)
-
-    def remote(self):
-        return self.filter(_is_remote=True)
 
 
 ##########
@@ -206,14 +185,6 @@ class User(AbstractUser):
     favorite_camera_medias = models.ManyToManyField(
         "cameras.CameraMedia", related_name="favorited_users", blank=True
     )
-
-    @property
-    def is_local(self):
-        return self.auth_id is None
-
-    @property
-    def is_remote(self):
-        return self.auth_id is not None
 
     @property
     def is_citizen(self) -> bool:

--- a/server/safers/users/permissions.py
+++ b/server/safers/users/permissions.py
@@ -18,19 +18,3 @@ class IsOwnerorAdmin(BasePermission):
         request_user = request.user
         view_user = view.user
         return request_user.is_superuser or request_user == view_user
-
-
-class IsRemote(BasePermission):
-    message = "Only remote users have permission to perform this action."
-
-    def has_permission(self, request, view):
-        user = request.user
-        return user.is_authenticated and user.is_remote
-
-
-class IsLocal(BasePermission):
-    message = "Only local users have permission to perform this action."
-
-    def has_permission(self, request, view):
-        user = request.user
-        return user.is_authenticated and user.is_local


### PR DESCRIPTION
Previous versions of the dashboard allowed users to login as a FusionAuth user or else as a local Django user.  The current version only supports FusionAuth.  Therefore all of the code that distinguishes between local & remote users can be removed.